### PR TITLE
fix: uuid.Parse panic for longer input strings

### DIFF
--- a/uuid/parse.go
+++ b/uuid/parse.go
@@ -86,6 +86,9 @@ func ParseExisting(uuid *UUID, corpus string) error {
 
 		hex[hexIndex] = hexChar
 		if hexIndex == 1 {
+			if uuidIndex > len((*uuid))-1 {
+				return ex.New(ErrParseInvalidLength)
+			}
 			(*uuid)[uuidIndex] = hex[0]<<4 | hex[1]
 			uuidIndex++
 			hexIndex = 0

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -91,6 +91,9 @@ func TestParseUUIDv4Invalid(t *testing.T) {
 
 	_, err = Parse("4f2e28b7b8f94b9eba1d90c4452")
 	assert.NotNil(err, "should handle invalid length uuids")
+
+	_, err = Parse("8678c61e-5655-409c-a926-9fb23be9b466eafd")
+	assert.NotNil(err, "should handle invalid length uuids")
 }
 
 type marshalTest struct {


### PR DESCRIPTION
fixes an issue with the `uuid.Parse` function where it would panic with an out-of-range index for longer input strings.

for example, when trying to parse a UUID with extra characters at the end `8678c61e-5655-409c-a926-9fb23be9b466eafd`:

```
panic: runtime error: index out of range [16] with length 16

goroutine 37 [running]:
testing.tRunner.func1.2({0x104597b60, 0xc000126138})
        /usr/local/go/src/testing/testing.go:1631 +0x2c8
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1634 +0x47c
panic({0x104597b60?, 0xc000126138?})
        /usr/local/go/src/runtime/panic.go:770 +0x124
github.com/blend/go-sdk/uuid.ParseExisting(0xc000068e20, {0x104515b01, 0x28})
        /Users/craig/code/blend-go-sdk/uuid/parse.go:92 +0x8f8
github.com/blend/go-sdk/uuid.Parse({0x104515b01, 0x28})
        /Users/craig/code/blend-go-sdk/uuid/parse.go:36 +0x5c
```